### PR TITLE
Included `has_one` relationships as relationships that get generated.

### DIFF
--- a/lib/generators/rest_kit/model/model_generator.rb
+++ b/lib/generators/rest_kit/model/model_generator.rb
@@ -132,7 +132,7 @@ module RestKit
       type = ''
       if macro_to_many? macro
         type = 'NSOrderedSet *'
-      elsif macro == :belongs_to
+      elsif [:belongs_to, :has_one].include? macro
         type = ios_class_name(name) + " *"
       end
       raise "Don't know how to turn association '#{macro}` '#{name}' into an Objective-C property" unless type


### PR DESCRIPTION
Small change just to also check if the association macro is `has_one` as well as `belongs_to`; as the `has_one` relationships were raising errors.
