### PR TITLE
Added the ability to specify additional columns in the `ios_sdk_config.yml` file.

### DIFF
--- a/lib/generators/rest_kit/ios_model_generator.rb
+++ b/lib/generators/rest_kit/ios_model_generator.rb
@@ -1,4 +1,5 @@
 require_relative './helpers'
+require 'ostruct'
 
 module RestKit
   # Abstract base class for iOS Mapping, Model and Route generators.
@@ -83,9 +84,32 @@ module RestKit
     def columns
       columns = model.columns
       columns = columns.select{|c| not c.name.in? excluded_columns }
+      columns += additional_columns
       columns
     end
 
+    # @param model_name [String] The model's name
+    # @return [Array<String>] Columns to exclude for this model. Returns an empty array if none.
+    def excluded_columns_for_model(model_name)
+      config.fetch(:models, {}).fetch(model_name, {}).fetch(:exclude, [])
+    end
+
+    # @param model_name [String] The model's name
+    # @return [Array<Object>] Columns to add for this model (iOS config file should define name and type).
+    # Returns an empty array if none.
+    def additional_columns
+      additions = config.fetch(:models, {}).fetch(model_name, {}).fetch(:additions, [])
+
+      columns = []
+      additions.each do |a|
+        columns << photo = OpenStruct.new(
+          name: a[:name],
+          type: a[:type]
+        )
+      end
+
+      columns
+    end
     include RestKit::Helpers
 
   end


### PR DESCRIPTION
Currently, you could only exclude columns from the Rails backend that you didn't want to persist on the mobile app. This change allows for the opposite, which is to define additional properties that you would want to persist on the app, but not in the backend. For example:

```
User:
  additions:
    - name: active_account
      type: string
```
