### PR TITLE
Feature/config cleanup

### DIFF
--- a/lib/generators/rest_kit/all/all_generator.rb
+++ b/lib/generators/rest_kit/all/all_generator.rb
@@ -26,7 +26,7 @@ class RestKit::AllGenerator < Rails::Generators::Base
 
   # @return [Array<String>] Model class names that we want to exclude, according to the config file.
   def excluded_model_class_names
-    config[:exclude_models]
+    config.excluded_models
   end
 
   # @return [Array<String] Model class names that we want included in the SDK.
@@ -46,20 +46,7 @@ class RestKit::AllGenerator < Rails::Generators::Base
   # @param model_name [String] The model's name
   # @return [Array<String>] Columns to exclude for this model. Returns an empty array if none.
   def excluded_columns_for_model(model_name)
-    # config[:models][model_name][:exclude]
-    config.fetch(:models, {}).fetch(model_name, {}).fetch(:exclude, [])
-  end
-
-  # Path of the YAML config file used to persist settings for excluding classes between runs
-  # of this generator.
-  # @return [String] Absolute path to the config file.
-  def config_file_path
-    Rails.root.join('.ios_sdk_config.yml')
-  end
-
-  # @return [Hash] Config loaded from YAML config file.
-  def config
-    @config ||= YAML.load(File.open(config_file_path)).with_indifferent_access
+    config.excluded_columns_for_model(model_name)
   end
 
   include RestKit::Helpers

--- a/lib/generators/rest_kit/config.rb
+++ b/lib/generators/rest_kit/config.rb
@@ -1,0 +1,54 @@
+require 'ostruct'
+
+module RestKit
+  class Config
+
+    def initialize
+      @options = parse_config
+    end
+
+    def models
+      @options.fetch(:models, {})
+    end
+
+    def excluded_models
+      @options.fetch(:exclude_models, {})
+    end
+
+    # @param model_name [String] The model's name
+    # @return [Array<String>] Columns to exclude for this model. Returns an empty array if none.
+    def excluded_columns_for_model(model_name)
+      models.fetch(model_name, {}).fetch(:exclude, [])
+    end
+
+    # @param model_name [String] The model's name
+    # @return [Array<Object>] Columns to add for this model (iOS config file should define name and type).
+    # Returns an empty array if none.
+    def additional_columns_for_model(model_name)
+      models.fetch(model_name, {}).fetch(:additions, []).map { |addition|
+        OpenStruct.new(
+          name: addition[:name],
+          type: addition[:type]
+        )
+      }
+    end
+
+    private
+
+    # Path of the YAML config file used to persist settings for excluding classes between runs
+    # of this generator.
+    # @return [String] Absolute path to the config file.
+    def config_file_path
+      Rails.root.join('.ios_sdk_config.yml')
+    end
+
+    # @return [Hash] Config loaded from YAML config file.
+    def parse_config
+      YAML.load(File.open(config_file_path)).with_indifferent_access
+    rescue => e
+      puts "No .ios_sdk_config.yml file found!"
+      {}
+    end
+
+  end
+end

--- a/lib/generators/rest_kit/config.rb
+++ b/lib/generators/rest_kit/config.rb
@@ -2,9 +2,8 @@ require 'ostruct'
 
 module RestKit
   class Config
-
-    def initialize
-      @options = parse_config
+    def initialize(config_file_path)
+      @options = parse_config(config_file_path)
     end
 
     def models
@@ -25,7 +24,7 @@ module RestKit
     # @return [Array<Object>] Columns to add for this model (iOS config file should define name and type).
     # Returns an empty array if none.
     def additional_columns_for_model(model_name)
-      models.fetch(model_name, {}).fetch(:additions, []).map { |addition|
+      models.fetch(model_name, {}).fetch(:additions, {}).map { |addition|
         OpenStruct.new(
           name: addition[:name],
           type: addition[:type]
@@ -35,15 +34,8 @@ module RestKit
 
     private
 
-    # Path of the YAML config file used to persist settings for excluding classes between runs
-    # of this generator.
-    # @return [String] Absolute path to the config file.
-    def config_file_path
-      Rails.root.join('.ios_sdk_config.yml')
-    end
-
     # @return [Hash] Config loaded from YAML config file.
-    def parse_config
+    def parse_config(config_file_path)
       YAML.load(File.open(config_file_path)).with_indifferent_access
     rescue => e
       puts "No .ios_sdk_config.yml file found!"

--- a/lib/generators/rest_kit/helpers.rb
+++ b/lib/generators/rest_kit/helpers.rb
@@ -1,3 +1,5 @@
+require_relative './config'
+
 module RestKit
   module Helpers
 
@@ -17,6 +19,10 @@ module RestKit
           system 'pod install --no-repo-update'
         }
       }
+    end
+
+    def config
+      @config ||= Config.new()
     end
 
     # @return [Array<String>] Model class names that we want to exclude by default. Used to seed the config file.

--- a/lib/generators/rest_kit/helpers.rb
+++ b/lib/generators/rest_kit/helpers.rb
@@ -22,26 +22,7 @@ module RestKit
     end
 
     def config
-      @config ||= Config.new()
-    end
-
-    # @return [Array<String>] Model class names that we want to exclude by default. Used to seed the config file.
-    def default_excluded_model_class_names
-      default_exclusion_regexes = [
-        /AdminUser$/,
-        /ActiveAdmin/
-      ]
-
-      all_model_class_names.select{ |name|
-        default_exclusion_regexes.any? { |pattern| pattern =~ name }
-      }
-    end
-
-    # @return [Hash] Config to be written to our config file as YAML.
-    def default_config_hash
-      {
-        'exclude_models' => default_excluded_model_class_names
-      }
+      @config ||= Config.new(config_file_path)
     end
 
     # @return [Array<String>] All model class names in the Rails project
@@ -50,6 +31,23 @@ module RestKit
         Dir[Rails.root.join("app/models/**/*.rb")].each {|file| require file }
         ActiveRecord::Base.descendants.map(&:name)
       }.call
+    end
+
+    # @return [Array<String>] Model class names that we want to exclude, according to the config file.
+    def excluded_model_class_names
+      config.excluded_models
+    end
+
+    # @return [Array<String] Model class names that we want included in the SDK.
+    def model_class_names
+      all_model_class_names - excluded_model_class_names
+    end
+
+    # Path of the YAML config file used to persist settings for excluding classes between runs
+    # of this generator.
+    # @return [String] Absolute path to the config file.
+    def config_file_path
+      Rails.root.join('.ios_sdk_config.yml')
     end
 
   end

--- a/lib/generators/rest_kit/install/install_generator.rb
+++ b/lib/generators/rest_kit/install/install_generator.rb
@@ -27,6 +27,25 @@ module RestKit
       end
     end
 
+    # @return [Array<String>] Model class names that we want to exclude by default. Used to seed the config file.
+    def default_excluded_model_class_names
+      default_exclusion_regexes = [
+        /AdminUser$/,
+        /ActiveAdmin/
+      ]
+
+      all_model_class_names.select{ |name|
+        default_exclusion_regexes.any? { |pattern| pattern =~ name }
+      }
+    end
+
+    # @return [Hash] Config to be written to our config file as YAML.
+    def default_config_hash
+      {
+        'exclude_models' => default_excluded_model_class_names
+      }
+    end
+
     include RestKit::Helpers
 
     private

--- a/lib/generators/rest_kit/ios_model_generator.rb
+++ b/lib/generators/rest_kit/ios_model_generator.rb
@@ -1,5 +1,4 @@
 require_relative './helpers'
-require 'ostruct'
 
 module RestKit
   # Abstract base class for iOS Mapping, Model and Route generators.
@@ -28,7 +27,7 @@ module RestKit
       ios_project_root = options[:ios_path]
       raise "Couldn't find iOS project at #{ios_project_root}" unless File.directory? File.expand_path(ios_project_root)
 
-      return Dir[File.join(File.expand_path(ios_project_root), "**/#{filename}")].reject{ |f| 
+      return Dir[File.join(File.expand_path(ios_project_root), "**/#{filename}")].reject{ |f|
         f.include? File.join(File.expand_path(ios_project_root), "Generated") \
         or f.include? File.join(File.expand_path(ios_project_root), "Pods")
       }.length > 0
@@ -94,39 +93,12 @@ module RestKit
       columns
     end
 
-    # @param model_name [String] The model's name
-    # @return [Array<String>] Columns to exclude for this model. Returns an empty array if none.
     def excluded_columns_for_model(model_name)
-      config.fetch(:models, {}).fetch(model_name, {}).fetch(:exclude, [])
+      config.excluded_columns_for_model(model_name)
     end
 
-    # @param model_name [String] The model's name
-    # @return [Array<Object>] Columns to add for this model (iOS config file should define name and type).
-    # Returns an empty array if none.
     def additional_columns
-      additions = config.fetch(:models, {}).fetch(model_name, {}).fetch(:additions, [])
-
-      columns = []
-      additions.each do |a|
-        columns << photo = OpenStruct.new(
-          name: a[:name],
-          type: a[:type]
-        )
-      end
-
-      columns
-    end
-
-    # Path of the YAML config file used to persist settings for excluding classes between runs
-    # of this generator.
-    # @return [String] Absolute path to the config file.
-    def config_file_path
-      Rails.root.join('.ios_sdk_config.yml')
-    end
-
-    # @return [Hash] Config loaded from YAML config file.
-    def config
-      @config ||= YAML.load(File.open(config_file_path)).with_indifferent_access
+      config.additional_columns_for_model(model_name)
     end
 
     include RestKit::Helpers


### PR DESCRIPTION
Moved the config handling out into it's own class so there's not all this unwieldy hash parsing everywhere, and now it just happens in the one class, and the generators will just class those on the instance of the `Config` class it's using.