### PR TITLE
Feature/unpolymorphise relationships

### DIFF
--- a/lib/generators/rest_kit/all/all_generator.rb
+++ b/lib/generators/rest_kit/all/all_generator.rb
@@ -24,16 +24,6 @@ class RestKit::AllGenerator < Rails::Generators::Base
 
   private
 
-  # @return [Array<String>] Model class names that we want to exclude, according to the config file.
-  def excluded_model_class_names
-    config.excluded_models
-  end
-
-  # @return [Array<String] Model class names that we want included in the SDK.
-  def model_class_names
-    all_model_class_names - excluded_model_class_names
-  end
-
   # @return [Array<String>] Names of routes that we want included in the SDK.
   def route_names
     model_class_names.map do |model_name|

--- a/lib/generators/rest_kit/config.rb
+++ b/lib/generators/rest_kit/config.rb
@@ -11,7 +11,7 @@ module RestKit
     end
 
     def excluded_models
-      @options.fetch(:exclude_models, {})
+      @options.fetch(:exclude_models, [])
     end
 
     # @param model_name [String] The model's name

--- a/lib/generators/rest_kit/helpers.rb
+++ b/lib/generators/rest_kit/helpers.rb
@@ -50,5 +50,12 @@ module RestKit
       Rails.root.join('.ios_sdk_config.yml')
     end
 
+    def association_exists?(model, association)
+      singular_symbol = association.active_record.name.underscore.to_sym
+      plural_symbol = association.active_record.name.pluralize.underscore.to_sym
+
+      model.reflect_on_association(singular_symbol) || model.reflect_on_association(plural_symbol) ? true : false
+    end
+
   end
 end


### PR DESCRIPTION
Seeing as Core Data doesn't have a concept of polymorphic relationships like Rails does, we need to break those down into multiple relationships that map directly between the polymorphic itself, and every object that uses it.

i.e.

- Photograph: `belongs_to :subject` 
- Location: `has_many :photographs, as: :subject`
- User: `has_one :photograph, as: :subject`

This gets broken down and becomes:

- Photograph: `belongs_to :location`  
- Photograph: `belongs_to :user`  
- Location: `has_many :photographs`  
- User: `has_one :photograph`
