### PR TITLE
The iOS model generator now takes into account whether the entity has a ...

### DIFF
--- a/lib/generators/rest_kit/ios_model_generator.rb
+++ b/lib/generators/rest_kit/ios_model_generator.rb
@@ -98,9 +98,18 @@ module RestKit
 
     def columns
       columns = model.columns
+
+      if parent_class
+        columns.reject!{ |c| c.name.in?(parent_class.columns.map(&:name)) }
+      end
+
       columns = columns.select{|c| not c.name.in? excluded_columns }
       columns += additional_columns
       columns
+    end
+
+    def parent_class
+      model.base_class != model ? model.base_class : nil
     end
 
     def excluded_columns_for_model(model_name)

--- a/lib/generators/rest_kit/model/templates/entity.xml.erb
+++ b/lib/generators/rest_kit/model/templates/entity.xml.erb
@@ -1,4 +1,4 @@
-<entity name="<%= model_name %>" representedClassName="<%= model_name %>" syncable="YES">
+<entity name="<%= model_name %>" representedClassName="<%= model_name %>" <%= "parentEntity=\"#{parent_class.name}\"" if parent_class %> syncable="YES">
 <% columns.each do |column| -%>
   <attribute name="<%= ios_attr_name(column.name) %>" optional="YES" attributeType="<%= core_data_type(column.type) %>" syncable="YES" <% if column.name == 'id' -%>indexed="YES"<% end -%> />
 <% end -%>
@@ -9,6 +9,6 @@
   <relationship name="<%= ios_attr_name(ass.name) %>" optional="YES" ordered="YES" toMany="YES" deletionRule="Nullify" destinationEntity="<%= ios_class_name(ass.class_name) %>" syncable="YES" <% if inverse_of(ass) %>inverseName="<%= ios_attr_name(inverse_of(ass).name) %>" inverseEntity="<%= ios_class_name(ass.class_name) %>" <% end %>/>
 <% end -%>
 <% belongs_to_associations.each do |ass| -%>
-  <relationship name="<%= ios_attr_name(ass.name) %>" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="<%= ios_class_name(ass.class_name) %>" syncable="YES" <% if inverse_of(ass) %>inverseName="<%= ios_attr_name(inverse_of(ass).name) %>" inverseEntity="<%= ios_class_name(ass.class_name) %>" <% end %>/>  
+  <relationship name="<%= ios_attr_name(ass.name) %>" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="<%= ios_class_name(ass.class_name) %>" syncable="YES" <% if inverse_of(ass) %>inverseName="<%= ios_attr_name(inverse_of(ass).name) %>" inverseEntity="<%= ios_class_name(ass.class_name) %>" <% end %>/>
 <% end -%>
 </entity>


### PR DESCRIPTION
...base class above it in the class hierarchy. If it does, then it sets the parent class in the entity object, and doesn't duplicate the columns in the class / entity description.