### PR TITLE
Feature/modularised classes

### DIFF
--- a/lib/generators/rest_kit/ios_model_generator.rb
+++ b/lib/generators/rest_kit/ios_model_generator.rb
@@ -42,15 +42,19 @@ module RestKit
     end
 
     def ios_class_name(name)
-      name.to_s.singularize.camelize
+      name.to_s.singularize.camelize.gsub(/[:]/, '')
     end
 
     def ios_base_class_name(class_name=nil)
-      "_" + ios_class_name(class_name || model_name)
+      "_" + ios_class_name(class_name || entity_name)
     end
 
     def model_name
       name.camelize
+    end
+
+    def entity_name
+      model_name.gsub(/[:]/, '')
     end
 
     def model
@@ -110,6 +114,10 @@ module RestKit
 
     def parent_class
       model.base_class != model ? model.base_class : nil
+    end
+
+    def is_abstract?
+      # binding.pry
     end
 
     def excluded_columns_for_model(model_name)

--- a/lib/generators/rest_kit/model/model_generator.rb
+++ b/lib/generators/rest_kit/model/model_generator.rb
@@ -59,7 +59,7 @@ module RestKit
 
       # Add to elements list
       inject_into_file data_model_path, before: "</elements>" do |config|
-        "<element name=\"#{model_name}\" positionX=\"0\" positionY=\"0\" width=\"0\" height=\"0\"/>\n"
+        "<element name=\"#{entity_name}\" positionX=\"0\" positionY=\"0\" width=\"0\" height=\"0\"/>\n"
       end
     end
 

--- a/lib/generators/rest_kit/model/templates/entity.xml.erb
+++ b/lib/generators/rest_kit/model/templates/entity.xml.erb
@@ -1,4 +1,4 @@
-<entity name="<%= model_name %>" representedClassName="<%= model_name %>" <%= "parentEntity=\"#{parent_class.name}\"" if parent_class %> syncable="YES">
+<entity name="<%= entity_name %>" representedClassName="<%= entity_name %>" <%= "isAbstract=\"YES\"" if is_abstract? %> <%= "parentEntity=\"#{parent_class.name}\"" if parent_class %> syncable="YES">
 <% columns.each do |column| -%>
   <attribute name="<%= ios_attr_name(column.name) %>" optional="YES" attributeType="<%= core_data_type(column.type) %>" syncable="YES" <% if column.name == 'id' -%>indexed="YES"<% end -%> />
 <% end -%>

--- a/lib/restkit_generators/version.rb
+++ b/lib/restkit_generators/version.rb
@@ -1,3 +1,3 @@
 module RestkitGenerators
-  VERSION = "0.0.2"
+  VERSION = "0.0.3"
 end


### PR DESCRIPTION
When using modules in your Rails app, i.e. `Chat::Message`, we need to break that out as Core Data doesn't have a concept of modules / name spacing.

We do this by just subbing out the colons, so where we had `Chat::Message`, the core data entity and class name will be `ChatMessage`.