### PR TITLE
Feature/timestamps

### DIFF
--- a/lib/generators/rest_kit/config.rb
+++ b/lib/generators/rest_kit/config.rb
@@ -32,6 +32,10 @@ module RestKit
       }
     end
 
+    def options_for_model(model_name)
+      models.fetch(model_name, {})
+    end
+
     private
 
     # @return [Hash] Config loaded from YAML config file.

--- a/lib/generators/rest_kit/helpers.rb
+++ b/lib/generators/rest_kit/helpers.rb
@@ -51,10 +51,19 @@ module RestKit
     end
 
     def association_exists?(model, association)
-      singular_symbol = association.active_record.name.underscore.to_sym
-      plural_symbol = association.active_record.name.pluralize.underscore.to_sym
+      singular_symbol = association.active_record.name.demodulize.underscore.to_sym
+      plural_symbol = association.active_record.name.demodulize.pluralize.underscore.to_sym
 
       model.reflect_on_association(singular_symbol) || model.reflect_on_association(plural_symbol) ? true : false
+    end
+
+    def polymorphic_association_exists?(model, association)
+      singular_symbol = association.active_record.name.demodulize.underscore.to_sym
+      plural_symbol = association.active_record.name.demodulize.pluralize.underscore.to_sym
+
+      poly_association = model.reflect_on_association(singular_symbol) || model.reflect_on_association(plural_symbol)
+
+      poly_association && poly_association.options[:as] == association.name ? true : false
     end
 
   end

--- a/lib/generators/rest_kit/ios_model_generator.rb
+++ b/lib/generators/rest_kit/ios_model_generator.rb
@@ -69,7 +69,7 @@ module RestKit
 
     def unpolymorphise(association)
       model_class_names.select { |m|
-        association_exists?(m.constantize, association)
+        polymorphic_association_exists?(m.constantize, association)
       }.map { |m|
         OpenStruct.new(name: m.underscore.to_sym, macro: :belongs_to, options: {})
       }

--- a/lib/generators/rest_kit/ios_model_generator.rb
+++ b/lib/generators/rest_kit/ios_model_generator.rb
@@ -89,7 +89,7 @@ module RestKit
 
     def excluded_columns
       excluded_columns = []
-      excluded_columns += ["created_at", "updated_at"] unless options[:include_timestamps]
+      excluded_columns += ["created_at", "updated_at"] unless include_timestamps?
 
       if options[:exclude_columns]
         excluded_columns += options[:exclude_columns].split(",") if options[:exclude_columns]
@@ -118,6 +118,10 @@ module RestKit
 
     def is_abstract?
       # binding.pry
+    end
+
+    def include_timestamps?
+      options[:include_timestamps] || config.options_for_model(model_name)[:include_timestamps]
     end
 
     def excluded_columns_for_model(model_name)

--- a/lib/restkit_generators/version.rb
+++ b/lib/restkit_generators/version.rb
@@ -1,3 +1,3 @@
 module RestkitGenerators
-  VERSION = "0.0.1"
+  VERSION = "0.0.5"
 end


### PR DESCRIPTION
Also fixed an issue where model generators were trying to un-polymorphise all relationships where the name matched, so we need to check that the name is set on the relationship under the `as:` attribute.