### PR TITLE
Added a method to detect the deletion rule for `has_many` relationships....

### DIFF
--- a/lib/generators/rest_kit/ios_model_generator.rb
+++ b/lib/generators/rest_kit/ios_model_generator.rb
@@ -83,6 +83,10 @@ module RestKit
       associations.select{ |a| not macro_to_many?(a.macro) }
     end
 
+    def ios_deletion_rule(association)
+      association.macro == :has_and_belongs_to_many ? "Nullify" : "Cascade"
+    end
+
     def macro_to_many?(macro)
       (macro == :has_many or macro == :has_and_belongs_to_many)
     end

--- a/lib/generators/rest_kit/model/templates/entity.xml.erb
+++ b/lib/generators/rest_kit/model/templates/entity.xml.erb
@@ -8,7 +8,7 @@
   <attribute name="<%= ios_attr_name(a.name.to_s.singularize + "_ids") %>" optional="YES" attributeType="Transformable" syncable="YES"/>
 <% end -%>
 <% has_many_associations.each do |ass| -%>
-  <relationship name="<%= ios_attr_name(ass.name) %>" optional="YES" ordered="YES" toMany="YES" deletionRule="Nullify" destinationEntity="<%= ios_class_name(ass.class_name) %>" syncable="YES" <% if inverse_of(ass) %>inverseName="<%= ios_attr_name(inverse_of(ass).name) %>" inverseEntity="<%= ios_class_name(ass.class_name) %>" <% end %>/>
+  <relationship name="<%= ios_attr_name(ass.name) %>" optional="YES" ordered="YES" toMany="YES" deletionRule="<%= ios_deletion_rule(ass) %>" destinationEntity="<%= ios_class_name(ass.class_name) %>" syncable="YES" <% if inverse_of(ass) %>inverseName="<%= ios_attr_name(inverse_of(ass).name) %>" inverseEntity="<%= ios_class_name(ass.class_name) %>" <% end %>/>
 <% end -%>
 <% belongs_to_associations.each do |ass| -%>
   <relationship name="<%= ios_attr_name(ass.name) %>" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="<%= ios_class_name(ass.class_name) %>" syncable="YES" <% if inverse_of(ass) %>inverseName="<%= ios_attr_name(inverse_of(ass).name) %>" inverseEntity="<%= ios_class_name(ass.class_name) %>" <% end %>/>


### PR DESCRIPTION
... Unless the relationship uses `has_and_belongs_to_many` we should use a cascading delete.

Resolves #17 