### PR TITLE
Features/validation generator

### DIFF
--- a/lib/generators/rest_kit/install/templates/podspec.erb
+++ b/lib/generators/rest_kit/install/templates/podspec.erb
@@ -8,8 +8,6 @@ Pod::Spec.new do |s|
   s.ios.deployment_target = '6.0'
   s.resources = 'Generated/**/DataModel.xcdatamodeld'
   s.dependency 'RestKit'
-   
-
 
   s.subspec 'Routes' do |ss|
     ss.source_files = 'Generated/Routes/*{h,m}'
@@ -21,5 +19,9 @@ Pod::Spec.new do |s|
 
   s.subspec 'Mappings' do |ss|
     ss.source_files = 'Generated/Mappings/*{h,m}'
+  end
+
+  s.subspec 'Validators' do |ss|
+    ss.source_files = 'Generated/Validators/*{h,m}'
   end
 end

--- a/lib/generators/rest_kit/ios_model_generator.rb
+++ b/lib/generators/rest_kit/ios_model_generator.rb
@@ -7,6 +7,7 @@ module RestKit
     class_option :include_timestamps, type: :boolean, default: false
     class_option :skip_pod_install, type: :boolean, required: false, default: false
     class_option :exclude_columns, type: :string, required: false, description: "Comma separated list of columns to exclude"
+    class_option :use_swift, type: :boolean, required: false, default: false, description: "Generate a swift version of the class instead of Objective-C"
 
     protected
 

--- a/lib/generators/rest_kit/validator/README.md
+++ b/lib/generators/rest_kit/validator/README.md
@@ -1,0 +1,20 @@
+# Validator Generator
+
+This generator will generate a validator extension for your class based on your Rails validations. For example:
+
+```
+validates :name, presence: true
+validates :body, presence: true
+```
+
+Will generate an extension that will allow your core data object to validate it's fields and ensure they pass the same validations that your Rails model would.
+
+## Usage:
+
+Validator generator can be called via:
+
+`rails g rest_kit:validator MODEL_NAME --ios-path=../path/to/ios/project`
+
+To generate Swift versions of validators, use:
+
+`rails g rest_kit:validator MODEL_NAME --ios-path=../path/to/ios/project --use-swift=true`

--- a/lib/generators/rest_kit/validator/templates/extension.swift.erb
+++ b/lib/generators/rest_kit/validator/templates/extension.swift.erb
@@ -1,5 +1,15 @@
-extension SupplierAccount {
-    func errorMsg(field: String) -> String {
+extension <%= model_name%> {
+    func validate() -> Bool {
+        let validator = createValidator()
+
+        if hasErrors(validator: validator) {
+            return false
+        }
+
+        return true
+    }
+
+    private func errorMessage(field: String) -> String {
         let messageMap: [String : String] = [
         <%- presence_validations.each do |validation| -%>
             "<%= validation.camelize(:lower) %>" : "k<%= model_name %>No<%= validation.camelize %>",
@@ -9,21 +19,11 @@ extension SupplierAccount {
         if let localisableStringName = messageMap[field] {
             return NSLocalizedString(localisableStringName, comment: "Error field: \(field)")
         } else {
-            return NSLocalizedString("kSupplierGenericFailure", comment: "Error field missing: \(field)")
+            return NSLocalizedString("k<%= model_name %>GenericFailure", comment: "Error field missing: \(field)")
         }
     }
 
-    func validate() -> Bool {
-        let validator = initValidator()
-
-        if hasErrors(validator: validator) {
-            return false
-        }
-
-        return true
-    }
-
-    private func initValidator() -> PCDValidator {
+    private func createValidator() -> PCDValidator {
         var validator = PCDValidator(object: self)
         validator.addValidationForAttributes([
         <%- presence_validations.each do |validation| -%>
@@ -38,7 +38,7 @@ extension SupplierAccount {
         let errors = validator.validate() as [String]
 
         if let errorField = errors.first {
-            var message: String = errorMsg(errorField)
+            var message: String = errorMessage(errorField)
 
             PCDHUD.showErrorWithStatus(message)
 

--- a/lib/generators/rest_kit/validator/templates/extension.swift.erb
+++ b/lib/generators/rest_kit/validator/templates/extension.swift.erb
@@ -1,0 +1,51 @@
+extension SupplierAccount {
+    func errorMsg(field: String) -> String {
+        let messageMap: [String : String] = [
+        <%- presence_validations.each do |validation| -%>
+            "<%= validation.camelize(:lower) %>" : "k<%= model_name %>No<%= validation.camelize %>",
+        <%- end -%>
+        ]
+
+        if let localisableStringName = messageMap[field] {
+            return NSLocalizedString(localisableStringName, comment: "Error field: \(field)")
+        } else {
+            return NSLocalizedString("kSupplierGenericFailure", comment: "Error field missing: \(field)")
+        }
+    }
+
+    func validate() -> Bool {
+        let validator = initValidator()
+
+        if hasErrors(validator: validator) {
+            return false
+        }
+
+        return true
+    }
+
+    private func initValidator() -> PCDValidator {
+        var validator = PCDValidator(object: self)
+        validator.addValidationForAttributes([
+        <%- presence_validations.each do |validation| -%>
+            "<%= validation.camelize(:lower) %>",
+        <%- end -%>
+        ])
+
+        return validator
+    }
+
+    private func hasErrors(#validator: PCDValidator) -> Bool {
+        let errors = validator.validate() as [String]
+
+        if let errorField = errors.first {
+            var message: String = errorMsg(errorField)
+
+            PCDHUD.showErrorWithStatus(message)
+
+            return true
+        }
+
+        return false
+    }
+
+}

--- a/lib/generators/rest_kit/validator/templates/implementation.m.erb
+++ b/lib/generators/rest_kit/validator/templates/implementation.m.erb
@@ -1,0 +1,59 @@
+#import "<%= filename %>.h"
+
+@implementation <%= ios_base_class_name %> (Validation)
+
+- (BOOL)validate
+{
+  PCDValidator *validator = [self createValidator];
+
+  if ([self hasErrors:validator]) {
+    return false;
+  }
+
+  return true;
+}
+
+- (NSString *)errorMessage:(NSString *)field
+{
+    NSDictionary *messageMap = @{
+    <%- presence_validations.each do |validation| -%>
+    @"<%= validation.camelize(:lower) %>" : @"k<%= model_name %>No<%= validation.camelize %>",
+    <%- end -%>
+    };
+
+    if (messageMap[field]) {
+        return NSLocalizedString(messageMap[field], nil);
+    } else {
+        return NSLocalizedString(@"k<%= model_name %>GenericFailure", nil);
+    }
+}
+
+- (PCDValidator *)createValidator
+{
+    PCDValidator *validator = [[PCDValidator alloc] initWithObject:self];
+
+    [validator addValidationForAttributes:@[
+    <%- presence_validations.each do |validation| -%>
+    @"<%= validation.camelize(:lower) %>"
+    <%- end -%>
+    ]];
+
+    return validator;
+}
+
+- (BOOL)hasErrors:(PCDValidator *)validator
+{
+    NSArray *invalidKeyPaths = [validator validate];
+
+    if ([invalidKeyPaths firstObject]) {
+        NSString *message = [self errorMessage:[invalidKeyPaths firstObject]];
+
+        [PCDHUD showErrorWithStatus:message];
+
+        return true;
+    }
+
+    return false;
+}
+
+@end

--- a/lib/generators/rest_kit/validator/templates/interface.h.erb
+++ b/lib/generators/rest_kit/validator/templates/interface.h.erb
@@ -1,0 +1,11 @@
+#import "Generated.h"
+#import <RestKit/RestKit.h>
+#import <RestKit/CoreData.h>
+#import <PCDefaults/PCDValidator.h>
+#import <PCDefaults/PCDHUD.h>
+
+@interface <%= ios_base_class_name %> (Validation)
+
+- (BOOL)validate;
+
+@end

--- a/lib/generators/rest_kit/validator/validator_generator.rb
+++ b/lib/generators/rest_kit/validator/validator_generator.rb
@@ -11,6 +11,10 @@ module RestKit
       end
     end
 
+    def update_project
+      pod_install
+    end
+
     private
 
     def destination_path(path)

--- a/lib/generators/rest_kit/validator/validator_generator.rb
+++ b/lib/generators/rest_kit/validator/validator_generator.rb
@@ -7,7 +7,7 @@ module RestKit
         template "extension.swift.erb",   destination_path("#{filename}.swift")
       else
         template "interface.h.erb",       destination_path("#{filename}.h")
-        template "implementation.h.erb",  destination_path("#{filename}.m")
+        template "implementation.m.erb",  destination_path("#{filename}.m")
       end
     end
 
@@ -18,7 +18,7 @@ module RestKit
     end
 
     def filename
-      "#{ios_class_name(model_name)}+Validator"
+      "#{ios_base_class_name}+Validation"
     end
 
     def use_swift

--- a/lib/generators/rest_kit/validator/validator_generator.rb
+++ b/lib/generators/rest_kit/validator/validator_generator.rb
@@ -1,0 +1,39 @@
+module RestKit
+  class ValidatorGenerator < IosModelGenerator
+    source_root File.expand_path('../templates', __FILE__)
+
+    def generate_validator_extension
+      if use_swift
+        template "extension.swift.erb",   destination_path("#{filename}.swift")
+      else
+        template "interface.h.erb",       destination_path("#{filename}.h")
+        template "implementation.h.erb",  destination_path("#{filename}.m")
+      end
+    end
+
+    private
+
+    def destination_path(path)
+      super(File.join("Validators", path))
+    end
+
+    def filename
+      "#{ios_class_name(model_name)}+Validator"
+    end
+
+    def use_swift
+      options[:use_swift]
+    end
+
+    def validators
+      model.validators
+    end
+
+    def presence_validations
+      presence_validator = validators.find { |v| v.is_a? ActiveRecord::Validations::PresenceValidator }
+
+      presence_validator.try(:attributes).map(&:to_s) || []
+    end
+
+  end
+end


### PR DESCRIPTION
Adds the ability to generate a validator category for a model based off Rails validations. Couple things:

- Currently only caters for presence validations, using additional methods to pluck out the Rails validator you want to cater to, should be easy to add more.

- Don't think the Swift generators will work until the rest of the generators are also in Swift, but the template is there and should work. I'll test it out in a vanilla Swift app and make any fixes later.

- For existing projects, need to add in the validators subspec manually to get that to link properly on generation.