### PR TITLE
Issues/issue 32

### DIFF
--- a/lib/generators/rest_kit/route/route_generator.rb
+++ b/lib/generators/rest_kit/route/route_generator.rb
@@ -116,9 +116,9 @@ module RestKit
     # Root for the main object requested. Plural for index actions, singular for show and others.
     def root_name
       if route.defaults[:action] == "index"
-        model.model_name.downcase.pluralize
+        model.model_name.demodulize.downcase.pluralize
       else
-        model_name.downcase.singularize
+        model.model_name.demodulize.downcase.singularize
       end
     end
   end

--- a/lib/generators/rest_kit/route/route_generator.rb
+++ b/lib/generators/rest_kit/route/route_generator.rb
@@ -10,6 +10,9 @@ module RestKit
     class_option :serializer, type: :string, default: nil,\
      desc: "Name of the active_model_serializer from which infer RKResponseDescriptors"
 
+    class_option :model, type: :string, default: nil,\
+     desc: "Name of the active_model_serializer from which infer RKResponseDescriptors"
+
     def generate_route
       empty_directory destination_path("")
       template "interface.h.erb",       destination_path("#{filename}.h")
@@ -50,8 +53,10 @@ module RestKit
     end
 
     def model_name
-      model_name = route.name.split("_").last
+      model_name = options[:model].present? ? options[:model] : route.name.split("_").last
+
       raise "Can't infer serializer name from model name from '#{route.name}'" unless model_name
+
       model_name.singularize
     end
 


### PR DESCRIPTION
Resolves #32 

Allows a model name to be specified by passing through a model flag into the route generator.
i.e. `rails g rest_kit:route "api_awesome_jobs" --ios-path=../Test --serializer="Awesome::JobSerializer" --model="Awesome::Job"`
